### PR TITLE
rename PHUIErrorView to PHUIInfoView, closes #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,22 @@ Licensed under Apache v2. See LICENSE for full details
 
 Sprints and burndowns in Phabricator
 
-To install, [add this as a library](https://secure.phabricator.com/book/phabricator/article/libraries/) to phabricator.
+To install, [add this as a library](https://secure.phabricator.com/book/phabricator/article/libraries/) to phabricator. Specifically:
+
+1. Clone phabricator-sprint repository
+2. Configure phabricator configuration in phabricator/conf/local/local.json to include "load-libraries" key that points to phabricator-sprint repository, for example:
+
+```
+{
+  ...
+  ...
+  "load-libraries": {
+    "phabricator-sprint": "\/var\/srv\/phabricator\/phabricator-sprint"
+  }
+}
+```
+
+3. Run `arc liberate src` from within the phabricator-sprint repository
 
 You can then create projects with a name that includes "Sprint" and edit it to add a start date and end date. Then add some tasks to that project, and edit them to set some story points. After that, go to the project and click "View burndown" in the actions. You can also view a list of projects with burndowns by going to the Burndown application.
 

--- a/src/BurndownController.php
+++ b/src/BurndownController.php
@@ -50,7 +50,7 @@ final class BurndownController extends PhabricatorController {
       $tasks_table    = $data->buildTasksTable();
       $events_table   = $data->buildEventTable();
     } catch (BurndownException $e) {
-      $error_box = id(new PHUIErrorView())
+      $error_box = id(new PHUIInfoView())
         ->setTitle(pht('Burndown could not be rendered for this project'))
         ->setErrors(array($e->getMessage()));
     }


### PR DESCRIPTION
As per #7 and https://secure.phabricator.com/D11867, this fixes an unhandled exception when attempting to view the burndown chart on certain phabricator installations (in particular, versions after 3b2fa99c57db96fe446b54ac50d271e6974265b1).