### PR TITLE
Replace withAnyProjects invocation with withEdgeLogicPHIDs

### DIFF
--- a/src/BurndownData.php
+++ b/src/BurndownData.php
@@ -69,7 +69,7 @@ class BurndownData {
     // have activity in the project period.
     $tasks = id(new ManiphestTaskQuery())
       ->setViewer($viewer)
-      ->withAnyProjects(array($this->project->getPHID()))
+      ->withEdgeLogicPHIDs(PhabricatorProjectObjectHasProjectEdgeType::EDGECONST, PhabricatorQueryConstraint::OPERATOR_OR, array($this->project->getPHID()))
       ->needProjectPHIDs(true)
       ->execute();
 


### PR DESCRIPTION
Fixes an issue with the latest phabricator installations that no longer support `withAnyProjects` query type. For reference:

- https://secure.phabricator.com/T5051#111660
- https://gerrit.wikimedia.org/r/#/c/207415/3/src/view/reports/SprintReportOpenTasksView.php
